### PR TITLE
Bump version of Netdata to 1.37.1

### DIFF
--- a/netdata/CHANGELOG.md
+++ b/netdata/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.1.2] - 2023-01-12
+
+### Updated
+
+- Bump version of Netdata to 1.37.1
+
 ## [2.1.1] - 2022-08-29
 
 ### Updated

--- a/netdata/build.yaml
+++ b/netdata/build.yaml
@@ -10,4 +10,4 @@ labels:
   org.opencontainers.image.description: "Netdata https://www.netdata.cloud/ Monitor everything in real time. For free"
   org.opencontainers.image.source: "https://github.com/Gamma-Software/netdata-homeassistant-addon"
   org.opencontainers.image.licenses: "MIT License"
-  org.opencontainers.image.version: "2.1.1"
+  org.opencontainers.image.version: "2.1.2"

--- a/netdata/config.yaml
+++ b/netdata/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: Netdata
-version: "2.1.1"
+version: "2.1.2"
 slug: netdata
 description: Netdata - Monitor everything in real time
 url: "https://github.com/Gamma-Software/netdata-homeassistant-addon"


### PR DESCRIPTION
Fixes #13 

Bump netdata-homeassistant-addon version to trigger build with latest Netdata (1.37.1 as of time of writing)